### PR TITLE
Fix/min max dom to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING**: Changed `InputTypes` and `UITypes` enum values to reflect their enum names and what was documented in the `README`
+- **BREAKING**: Changed `min` and `max` props returned from `getInputProps()` to be strings, not numbers
+- **BREAKING**: Just re-exports types and `Controller` component from `react-hook-form`
 
 ## [0.2.0-beta.2] - 2020-01-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-beta.3] - 2020-01-31
+
 ### Changed
 
 - **BREAKING**: Changed `InputTypes` and `UITypes` enum values to reflect their enum names and what was documented in the `README`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-hook-form-jsonschema",
-  "version": "0.2.0-beta.2",
+  "version": "0.2.0-beta.3",
   "description": "Wrapper arround react-hook-form to create forms from a JSON schema.",
   "main": "output/index.cjs.js",
   "module": "output/index.esm.js",

--- a/src/hooks/useRawInput.ts
+++ b/src/hooks/useRawInput.ts
@@ -57,8 +57,8 @@ export const getRawInputCustomFields = (
 
     validator = getNumberValidator(currentObject, baseFields.isRequired)
 
-    itemProps.min = minimum
-    itemProps.max = maximum
+    itemProps.min = `${minimum}`
+    itemProps.max = `${maximum}`
     itemProps.step =
       step === 'any' ? 'any' : toFixed(step, decimalPlaces ? decimalPlaces : 0)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-export * from 'react-hook-form'
+export { Controller } from 'react-hook-form'
+export * from 'react-hook-form/dist/types'
 
 export { FormContext, FormContextProps } from './components'
 export * from './hooks'


### PR DESCRIPTION
#### What problem is this solving?

Fix a problem where react would complain that the `min` and `max` types returned from `getInputProps()` 

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
✔️ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
