### PR TITLE
Change onSubmit to pass form methods inside an object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-beta.7] - 2020-02-14
+
 ### Changed
 
 - **BREAKING**: `onSubmit` now passes an object with `data`, `event` and `methods` as members to the callback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `onSubmit` now passes an object with `data`, `event` and `methods` as members to the callback.
+
 ## [0.2.0-beta.6] - 2020-02-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -112,7 +112,10 @@ This component is the top-level component that creates the context with the sche
   - `'onChange'`: Validate when an input field value changes.
   - `'onSubmit'`: Validate when the submit is triggered.
 - `submitFocusError`: Boolean, when `true` focus on the first field with error after submit validates, if there is any. Defaults to `true`.
-- `onSubmit`: Callback function that the form values are passed to when submit is triggered without errors.
+- `onSubmit`: If provided `react-hook-form-jsonschema` will call this function as the submit action, it passes an object with the following members:
+  - `data`: The data that was provided as inputs to the form, correctly formatted as an instance of the JSON Schema provided.
+  - `event`: A react event
+  - `methods`: Provides access to the methods of [`react-hook-form`](https://react-hook-form.com/api) `useForm`, from this you can extract, for example, the `triggerValidation` method to revalidate the form if an error occured while submitting.
 - `noNativeValidate`: Boolean, when `true` disables the default browser validation (notice that `react-hook-form-jsonschema` does NOT yet implement validation for URIs and email addresses).
 
 ## Hooks API

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-hook-form-jsonschema",
-  "version": "0.2.0-beta.6",
+  "version": "0.2.0-beta.7",
   "description": "Wrapper arround react-hook-form to create forms from a JSON schema.",
   "main": "output/index.cjs.js",
   "module": "output/index.esm.js",

--- a/src/components/FormContext.tsx
+++ b/src/components/FormContext.tsx
@@ -51,7 +51,7 @@ export const FormContext: FC<FormContextProps> = props => {
 
   formProps.onSubmit = methods.handleSubmit(async (data, event) => {
     if (props.onSubmit) {
-      return await props.onSubmit({
+      return props.onSubmit({
         data: getObjectFromForm(props.schema, data),
         event: event,
         methods: formContext,

--- a/src/components/FormContext.tsx
+++ b/src/components/FormContext.tsx
@@ -31,11 +31,29 @@ export const FormContext: FC<FormContextProps> = props => {
     submitFocusError: submitFocusError,
   })
 
+  const idMap = useMemo(() => getIdSchemaPairs(props.schema), [props.schema])
+
+  const resolvedSchemaRefs = useMemo(
+    () => resolveRefs(props.schema, idMap, []),
+    [props.schema, idMap]
+  )
+
+  const formContext: JSONFormContextValues = {
+    ...methods,
+    schema: resolvedSchemaRefs,
+    idMap: idMap,
+    customValidators: props.customValidators,
+  }
+
   const formProps: React.ComponentProps<'form'> = {}
 
-  formProps.onSubmit = methods.handleSubmit((data, event) => {
+  formProps.onSubmit = methods.handleSubmit(async (data, event) => {
     if (props.onSubmit) {
-      props.onSubmit(getObjectFromForm(props.schema, data), event)
+      return await props.onSubmit({
+        data: getObjectFromForm(props.schema, data),
+        event: event,
+        methods: formContext,
+      })
     }
     return
   })
@@ -44,22 +62,8 @@ export const FormContext: FC<FormContextProps> = props => {
     formProps.noValidate = props.noNativeValidate
   }
 
-  const idMap = useMemo(() => getIdSchemaPairs(props.schema), [props.schema])
-
-  const resolvedSchemaRefs = useMemo(
-    () => resolveRefs(props.schema, idMap, []),
-    [props.schema, idMap]
-  )
-
   return (
-    <InternalFormContext.Provider
-      value={{
-        ...methods,
-        schema: resolvedSchemaRefs,
-        idMap: idMap,
-        customValidators: props.customValidators,
-      }}
-    >
+    <InternalFormContext.Provider value={formContext}>
       <form {...formProps}>{props.children}</form>
     </InternalFormContext.Provider>
   )

--- a/src/components/FormContext.tsx
+++ b/src/components/FormContext.tsx
@@ -38,12 +38,14 @@ export const FormContext: FC<FormContextProps> = props => {
     [props.schema, idMap]
   )
 
-  const formContext: JSONFormContextValues = {
-    ...methods,
-    schema: resolvedSchemaRefs,
-    idMap: idMap,
-    customValidators: props.customValidators,
-  }
+  const formContext: JSONFormContextValues = useMemo(() => {
+    return {
+      ...methods,
+      schema: resolvedSchemaRefs,
+      idMap: idMap,
+      customValidators: props.customValidators,
+    }
+  }, [methods, resolvedSchemaRefs, idMap, props.customValidators])
 
   const formProps: React.ComponentProps<'form'> = {}
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,7 @@
-export { FormContextProps, JSONFormContextValues } from './types'
+export {
+  FormContextProps,
+  JSONFormContextValues,
+  OnSubmitParameters,
+  OnSubmitType,
+} from './types'
 export { FormContext, useFormContext } from './FormContext'

--- a/src/components/types/index.ts
+++ b/src/components/types/index.ts
@@ -12,10 +12,12 @@ export interface JSONFormContextValues<
   customValidators?: CustomValidators
 }
 
-export type OnSubmitType = (
-  data: JSONSchemaType,
+export type OnSubmitParameters = {
+  data: JSONSchemaType
   event: React.BaseSyntheticEvent | undefined
-) => void | Promise<void>
+  methods: JSONFormContextValues
+}
+export type OnSubmitType = (props: OnSubmitParameters) => void | Promise<void>
 
 export type FormContextProps = {
   validationMode?: Mode

--- a/src/hooks/__tests__/useCheckbox.test.tsx
+++ b/src/hooks/__tests__/useCheckbox.test.tsx
@@ -30,7 +30,7 @@ test('should have boolean true and false', done => {
   const { getByText } = render(
     <FormContext
       schema={mockCheckboxSchema}
-      onSubmit={data => {
+      onSubmit={({ data }) => {
         expect(data.booleanTest).toBe(true)
         done()
       }}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,14 @@
 export { Controller } from 'react-hook-form'
 export * from 'react-hook-form/dist/types'
 
-export { FormContext, FormContextProps } from './components'
+export {
+  FormContext,
+  FormContextProps,
+  JSONFormContextValues,
+} from './components'
+
 export * from './hooks'
+
 export * from './JSONSchema'
 
 export {


### PR DESCRIPTION
#### What problem is this solving?

This PR solves the access the internal state controllers of the form on `onSubmit` callback, such as being able to indicate that the form should revalidate.

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
✔️ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
