### PR TITLE
Prevents onChange trigger on first render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-beta.13] - 2020-03-26
+
 ### Fixed
 
 - Prevent `onChange` from being triggered during the initial render.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent `onChange` from being triggered during the initial render.
+
 ## [0.2.0-beta.12] - 2020-03-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-hook-form-jsonschema",
-  "version": "0.2.0-beta.12",
+  "version": "0.2.0-beta.13",
   "description": "Wrapper arround react-hook-form to create forms from a JSON schema.",
   "main": "output/index.cjs.js",
   "module": "output/index.esm.js",

--- a/src/components/FormContext.tsx
+++ b/src/components/FormContext.tsx
@@ -35,8 +35,14 @@ export const FormContext: FC<FormContextProps> = props => {
     submitFocusError: submitFocusError,
   })
 
-  if (typeof onChange === 'function') {
-    onChange(getObjectFromForm(props.schema, methods.watch()))
+  const isFirstRender = React.useRef(true)
+
+  const watchedInputs = methods.watch()
+
+  if (isFirstRender.current === true) {
+    isFirstRender.current = false
+  } else if (typeof onChange === 'function') {
+    onChange(getObjectFromForm(props.schema, watchedInputs))
   }
 
   const idMap = useMemo(() => getIdSchemaPairs(props.schema), [props.schema])

--- a/src/components/FormContext.tsx
+++ b/src/components/FormContext.tsx
@@ -37,12 +37,12 @@ export const FormContext: FC<FormContextProps> = props => {
 
   const isFirstRender = React.useRef(true)
 
-  const watchedInputs = methods.watch()
+  if (typeof onChange === 'function') {
+    const watchedInputs = methods.watch()
 
-  if (isFirstRender.current === true) {
-    isFirstRender.current = false
-  } else if (typeof onChange === 'function') {
-    onChange(getObjectFromForm(props.schema, watchedInputs))
+    if (isFirstRender.current === false) {
+      onChange(getObjectFromForm(props.schema, watchedInputs))
+    }
   }
 
   const idMap = useMemo(() => getIdSchemaPairs(props.schema), [props.schema])
@@ -76,6 +76,10 @@ export const FormContext: FC<FormContextProps> = props => {
 
   if (props.noNativeValidate) {
     formProps.noValidate = props.noNativeValidate
+  }
+
+  if (isFirstRender.current === true) {
+    isFirstRender.current = false
   }
 
   return (

--- a/src/components/__mocks__/mockSchema.ts
+++ b/src/components/__mocks__/mockSchema.ts
@@ -1,0 +1,25 @@
+const mockSchema = {
+  $id: 'https://example.com/mock.schema.json',
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'Mock',
+  type: 'object',
+  properties: {
+    firstField: {
+      type: 'string',
+      description: 'The first field.',
+      title: 'First field',
+    },
+    secondField: {
+      type: 'string',
+      description: 'The second field.',
+      title: 'Second field',
+    },
+    thirdField: {
+      type: 'string',
+      description: 'The third field.',
+      title: 'Third field',
+    },
+  },
+}
+
+export default mockSchema

--- a/src/components/__tests__/FormContext.test.tsx
+++ b/src/components/__tests__/FormContext.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render } from '@vtex/test-tools/react'
+import React from 'react'
+import { Controller } from 'react-hook-form'
+
+import { useObject } from '../../hooks/useObject'
+import mockSchema from '../__mocks__/mockSchema'
+import { FormContext } from '../FormContext'
+
+const ObjectRenderer = (props: { pointer: string }) => {
+  const fields = useObject({ pointer: props.pointer })
+
+  return (
+    <>
+      {fields.map(field => {
+        const fieldJsonSchema = field.getObject()
+
+        return (
+          <Controller
+            as={<input aria-label={fieldJsonSchema.title} name={field.name} />}
+            control={field.formContext.control}
+            defaultValue=""
+            key={field.pointer}
+            name={field.pointer}
+          />
+        )
+      })}
+    </>
+  )
+}
+
+test('should call onChange when something changes', () => {
+  const changeHandlerMock = jest.fn()
+
+  const { getByLabelText } = render(
+    <FormContext onChange={changeHandlerMock} schema={mockSchema}>
+      <ObjectRenderer pointer="#" />
+    </FormContext>
+  )
+
+  expect(changeHandlerMock).toHaveBeenCalledTimes(0)
+
+  let changeValue
+
+  Object.entries(mockSchema.properties).forEach(
+    ([fieldName, fieldProperties], index) => {
+      const fieldNumber = index + 1
+
+      const inputElement = getByLabelText(fieldProperties.title)
+
+      const fieldNewValue = `new value for field ${fieldNumber}`
+
+      fireEvent.change(inputElement, {
+        target: { value: fieldNewValue },
+      })
+
+      expect(changeHandlerMock).toHaveBeenCalledTimes(fieldNumber)
+
+      changeValue = { ...changeValue, [fieldName]: fieldNewValue }
+
+      expect(changeHandlerMock).toHaveBeenLastCalledWith(changeValue)
+    }
+  )
+})


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

Prevents `onChange` from being triggered during the initial render.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Example usage

```ts
const handleChange = () => {
  console.log("You shouldn't be seeing this if you haven't made changes!")
}
```

```tsx
<FormContext
  onChange={handleChange}
  // ...
>
  ...
</FormContext>
```

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

N/A.