### PR TITLE
List values in `enum` attribute on `useRadio`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- List values in `enum` attribute on `useRadio`
+
 ## [0.2.0] - 2021-08-03
 
 ## [0.2.0-beta.13] - 2020-03-26

--- a/src/hooks/__mocks__/mockSchema.ts
+++ b/src/hooks/__mocks__/mockSchema.ts
@@ -19,6 +19,11 @@ const mockSchema = {
       maximum: 6,
       multipleOf: 2,
     },
+    integerEnumTest: {
+      type: 'integer',
+      title: 'test-useSelectIntegerEnum',
+      enum: [0, 1, 2, 3, 5, 7, 11, 13],
+    },
     numberTest: {
       type: 'number',
       title: 'test-useSelectNumber',

--- a/src/hooks/__tests__/useRadio.test.tsx
+++ b/src/hooks/__tests__/useRadio.test.tsx
@@ -91,3 +91,20 @@ test('should raise error', async () => {
 
   await wait(() => expect(getByText('This is an error!')).toBeDefined())
 })
+
+test('should integer enum values', () => {
+  const { getByText } = render(
+    <FormContext schema={mockRadioSchema}>
+      <MockRadio pointer="#/properties/integerEnumTest" />
+    </FormContext>
+  )
+
+  expect(getByText('0')).toBeDefined()
+  expect(getByText('1')).toBeDefined()
+  expect(getByText('2')).toBeDefined()
+  expect(getByText('3')).toBeDefined()
+  expect(getByText('5')).toBeDefined()
+  expect(getByText('7')).toBeDefined()
+  expect(getByText('11')).toBeDefined()
+  expect(getByText('13')).toBeDefined()
+})

--- a/src/hooks/useRadio.ts
+++ b/src/hooks/useRadio.ts
@@ -51,16 +51,20 @@ export const getRadioCustomFields = (
     currentObject.type === 'number' ||
     currentObject.type === 'integer'
   ) {
-    const stepAndDecimalPlaces = getNumberStep(currentObject)
-    step = stepAndDecimalPlaces[0]
-    decimalPlaces = stepAndDecimalPlaces[1]
+    if (currentObject.enum) {
+      items = getEnumAsStringArray(currentObject)
+    } else {
+      const stepAndDecimalPlaces = getNumberStep(currentObject)
+      step = stepAndDecimalPlaces[0]
+      decimalPlaces = stepAndDecimalPlaces[1]
 
-    minimum = getNumberMinimum(currentObject)
-    maximum = getNumberMaximum(currentObject)
+      minimum = getNumberMinimum(currentObject)
+      maximum = getNumberMaximum(currentObject)
 
-    if (minimum !== undefined && maximum !== undefined && step != 'any') {
-      for (let i = minimum; i <= maximum; i += step) {
-        items.push(toFixed(i, decimalPlaces ? decimalPlaces : 0))
+      if (minimum !== undefined && maximum !== undefined && step != 'any') {
+        for (let i = minimum; i <= maximum; i += step) {
+          items.push(toFixed(i, decimalPlaces ? decimalPlaces : 0))
+        }
       }
     }
   } else if (currentObject.type === 'boolean') {

--- a/src/hooks/validators/getEnum.ts
+++ b/src/hooks/validators/getEnum.ts
@@ -1,7 +1,7 @@
 import { JSONSchemaType, JSONSchemaBaseInstanceTypes } from '../../JSONSchema'
 
 const mapEnumItemsToString = (obj: JSONSchemaBaseInstanceTypes): string => {
-  if (obj) {
+  if (obj !== null && obj !== undefined) {
     return obj.toString()
   }
   return ''


### PR DESCRIPTION
#### What problem is this solving?

I have `integer`-type property with `enum` in JSON schema like following.

```json
"sample": {
  "enum": [
    1,
    2
  ],
  "type": "integer",
  "description": "Sample",
  "format": "int32"
} 
```

I would like to create radio fields with values in `enum` attributes.

#### Checklist/Reminders

- [ ] ~~Updated `README.md`.~~ (Do I need to update?)
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️  | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
